### PR TITLE
Fix Makefile errors for out of tree builds wrt TestRunner.cpp

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -1,8 +1,8 @@
 Installation Instructions
 *************************
 
-   Copyright (C) 1994-1996, 1999-2002, 2004-2016 Free Software
-Foundation, Inc.
+   Copyright (C) 1994-1996, 1999-2002, 2004-2017, 2020-2021 Free
+Software Foundation, Inc.
 
    Copying and distribution of this file, with or without modification,
 are permitted in any medium without royalty provided the copyright
@@ -225,7 +225,7 @@ order to use an ANSI C compiler:
 
 and if that doesn't work, install pre-built binaries of GCC for HP-UX.
 
-   HP-UX 'make' updates targets which have the same time stamps as their
+   HP-UX 'make' updates targets which have the same timestamps as their
 prerequisites, which makes it generally unusable when shipped generated
 files such as 'configure' are involved.  Use GNU 'make' instead.
 

--- a/tclplus/Makefile.am
+++ b/tclplus/Makefile.am
@@ -119,13 +119,13 @@ tracetests_DEPENDENCIES = $(testableObjects)
 
  tracetests_LDADD = $(TestLdflags) @TCL_LIBS@ @CPPUNIT_LIBS@
 
- interptests_SOURCES=interpretertest.cpp objecttest.cpp resulttest.cpp \
+ interptests_SOURCES=TestRunner.cpp interpretertest.cpp objecttest.cpp resulttest.cpp \
 	objcommandtest.cpp compatcommand.cpp packagetests.cpp
 
- interptests_LDADD = TestRunner.lo $(TestLdflags) @CPPUNIT_LIBS@
+ interptests_LDADD = $(TestLdflags) @CPPUNIT_LIBS@
 
 
-interptests_DEPENDENCIES = $(testableObjects) TestRunner.lo
+interptests_DEPENDENCIES = $(testableObjects) 
 
 tcpservertest_SOURCES	= 	tcpservertest.cpp
 tcpservertest_DEPENDENCIES	= 	libtclPlus.la
@@ -136,8 +136,8 @@ tcpservertest_LDFLAGS	= 	-Wl,"-rpath-link=$(libdir)" @TCL_LIBS@ @CPPUNIT_LIBS@
 
 
 threadtests_DEPENENCIES = $(testableObjects)
-threadtests_SOURCES     = threadtests.cpp mutextests.cpp
-threadtests_LDADD      = $(testableObjects) TestRunner.lo \
+threadtests_SOURCES     = TestRunner.cpp threadtests.cpp mutextests.cpp
+threadtests_LDADD      = $(testableObjects)  \
                                 @top_builddir@/exception/libException.la \
                         @TCL_LIBS@ @CPPUNIT_LIBS@
 


### PR DESCRIPTION
TestRunner.lo was referred to rather than having TestRunner.cpp a source in all tests.   This is incorrect as the actual .lo is xxx_TestRunner.log where xxx is whatever built the target.