### PR TITLE
Issue #3 - don't build tests until make check

### DIFF
--- a/exception/Makefile.am
+++ b/exception/Makefile.am
@@ -40,7 +40,7 @@ install-data-local:
 #	        $(DESTDIR)/$(prefix)/include/CErrnoException.h
 
 
-noinst_PROGRAMS = unittests
+check_PROGRAMS = unittests
 unittests_SOURCES = TestRunner.cpp testException.cpp testErrnoException.cpp \
 	testStreamIOError.cpp testRangeError.cpp
 unittests_LDADD   = @CPPUNIT_LIBS@ libException.la

--- a/tclplus/Makefile.am
+++ b/tclplus/Makefile.am
@@ -104,8 +104,8 @@ clean-local:
 
 EXTRA_DIST = tkAppInit.c tclplus.xml
 
-### disabled for now, will have fox hook these back up
- noinst_PROGRAMS = tracetests interptests tcpservertest threadtests
+
+check_PROGRAMS = tracetests interptests tcpservertest threadtests
 
 tracetests_SOURCES = TestRunner.cpp \
 			ccallbacktest.cpp \


### PR DESCRIPTION
Altered Makefile.am to use check_PROGRAMS for to build tests. This should speed up the incorp builds so I'll merge/tag.

Resolve issue #3 